### PR TITLE
ReleaseAcquire semantics tests + small build setup refinements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ target_compile_options(engine PRIVATE -Wall -Wextra -Wpedantic)
 add_executable(executor main.cpp)
 target_link_libraries(executor PRIVATE engine)
 
+option(ENABLE_TESTS "Enable tests build" ON)
+
 if (ENABLE_TESTS)
     add_subdirectory(tests)
 endif ()

--- a/build-utils/build_debug.sh
+++ b/build-utils/build_debug.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+mkdir "$1"
+cmake . -D CMAKE_BUILD_TYPE=Debug
+cmake --build "$1"

--- a/build-utils/build_release.sh
+++ b/build-utils/build_release.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+mkdir "$1"
+cmake . -D CMAKE_BUILD_TYPE=Release ENABLE_TESTS=OFF
+cmake --build "$1"

--- a/main.cpp
+++ b/main.cpp
@@ -87,7 +87,7 @@ int main(int argc, char** argv) {
             std::cout << "Program is correct\n";
         } catch (FailError&) {
             auto trace = checker->GetTrace();
-            std::cout << "\"fail\" found, stacktrace:\n";
+            std::cout << "\"fail\" found, choices were:\n";
             for (auto i : trace) {
                 std::cout << i << '\n';
             }

--- a/src/defs.cpp
+++ b/src/defs.cpp
@@ -44,9 +44,7 @@ std::ostream& operator<<(std::ostream& out, BinaryOperator op) {
     return out;
 }
 
-std::ostream& operator<<(std::ostream& out, Register reg) {
-    return out << 'r' << static_cast<int>(reg);
-}
+std::ostream& operator<<(std::ostream& out, Register reg) { return out << 'r' << static_cast<int>(reg); }
 
 MemoryOrder ExtractLoadOrder(MemoryOrder order) {
     switch (order) {
@@ -58,6 +56,8 @@ MemoryOrder ExtractLoadOrder(MemoryOrder order) {
         case MemoryOrder::SEQ_CST:
         case MemoryOrder::REL:
             throw RuntimeError{"Bad memory order for reading"};
+        default:
+            throw RuntimeError{"Unsupported memory order"};
     }
 }
 
@@ -71,5 +71,7 @@ MemoryOrder ExtractStoreOrder(MemoryOrder order) {
         case MemoryOrder::SEQ_CST:
         case MemoryOrder::ACQ:
             throw RuntimeError{"Bad memory order for reading"};
+        default:
+            throw RuntimeError{"Unsupported memory order"};
     }
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(test)
 
 add_subdirectory(tokenizer)
 add_subdirectory(parser)
+add_subdirectory(release_acquire)
 
 target_link_libraries(test PRIVATE Catch2::Catch2WithMain)
 target_link_libraries(test PRIVATE engine)

--- a/tests/release_acquire/CMakeLists.txt
+++ b/tests/release_acquire/CMakeLists.txt
@@ -1,0 +1,1 @@
+target_sources(test PRIVATE test.cpp)

--- a/tests/release_acquire/test.cpp
+++ b/tests/release_acquire/test.cpp
@@ -1,0 +1,110 @@
+#include <catch2/catch_test_macros.hpp>
+#include "defs.h"
+
+#include <parser.h>
+#include <program.h>
+#include <tokenizer.h>
+#include <path_choosers/full.h>
+
+const std::string kDekkerLockProgram = R"(
+r0 = + r1 r15
+r1 = 1
+r2 = 1
+r3 = 5
+store REL #r3 r2
+if r0 goto t2
+if r1 goto t1
+fail
+t1: r0 = 0
+store REL #r0 r2
+load ACQ #r1 r10
+store REL #r3 r10
+finish
+t2: r0 = 0
+store REL #r1 r2
+load ACQ #r0 r11
+load ACQ #r3 r10
+if r10 goto end
+if r11 goto end
+fail
+end: finish
+
+-----
+      z = 1
+    x = y = 0
+x   = 1 | y   = 1
+r10 = y | r11 = x
+z = r10 | assert not z == 0 && r11 == 0
+)";
+
+const std::string kMessagePassingProgram = R"(
+r0 = + r0 r15
+r1 = 1
+if r0 goto t2+
+if r1 goto t1
+t2+: r0 = - r0 r1
+if r0 goto bad
+if r1 goto t2
+t1: r0 = 0
+r1 = 1
+load ACQ #r1 r11
+load RLX #r0 r10
+if r11 goto check
+finish
+check: if r10 goto end
+bad: fail
+t2: r0 = 0
+r1 = 1
+r2 = 1
+store RLX #r0 r2
+store REL #r1 r2
+end: finish
+
+-----
+    x = y = 0
+r11 = y (ACQ) | x = 1 (RLX)
+r10 = x (RLX) | y = 1 (REL)
+assert not r10 == 0 && r11 == 1 | skip)";
+
+TEST_CASE("Dekker lock fails under RA") {
+    constexpr auto kModel = MemoryModel::RA;
+    constexpr std::size_t kThreadsCount = 2;
+    std::stringstream ss(kDekkerLockProgram);
+    Tokenizer tokenizer{ss};
+    auto code = Parse(tokenizer);
+    auto checker = std::make_shared<FullChooser>();
+    Program program(std::move(code), kThreadsCount, checker);
+    try {
+        while (!checker->Finished()) {
+            constexpr std::size_t kMemorySize = 8;
+            program.Init(kModel, kMemorySize);
+            program.SetVerbosity(false);
+            program.Run();
+            checker->NextRun();
+        }
+        REQUIRE(false);
+    } catch (FailError&) {
+    }
+}
+
+TEST_CASE("Message passing works") {
+    constexpr auto kModel = MemoryModel::RA;
+    constexpr std::size_t kThreadsCount = 2;
+    std::stringstream ss(kMessagePassingProgram);
+    Tokenizer tokenizer{ss};
+    auto code = Parse(tokenizer);
+    auto checker = std::make_shared<FullChooser>();
+    Program program(std::move(code), kThreadsCount, checker);
+    try {
+        while (!checker->Finished()) {
+            constexpr std::size_t kMemorySize = 8;
+            program.Init(kModel, kMemorySize);
+            program.SetVerbosity(false);
+            program.Run();
+            checker->NextRun();
+        }
+    } catch (FailError&) {
+        // fail in case there was 'fail' instruction reached
+        REQUIRE(false);
+    }
+}


### PR DESCRIPTION
Added tests that test for certain phenomenons that are specific to ReleaseAcquire semantics.

1.  One test demonstrates that Dekker's lock, a classic mutual exclusion algorithm, fails under release–acquire (RA) semantics. This failure happens because Dekker's algorithm relies on the stronger ordering of sequential consistency, and RA semantics only ensure that a release operation makes previous writes visible to a corresponding acquire—not that all operations occur in a single, global order. In essence, this test shows that older synchronization algorithms may not work correctly on modern architectures that use weaker memory models.

2. The other test confirms that message passing works as expected under RA semantics. Message passing is a key mechanism in concurrent programming for safely transferring data between threads. By ensuring that a release in one thread properly synchronizes with an acquire in another, this test validates that data written by the sender is correctly seen by the receiver.